### PR TITLE
Build godwoken-scripts in godwoken/gwos

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,7 +64,7 @@ jobs:
       # GitHub automatically creates a unique GITHUB_TOKEN secret to use in this workflow.
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.ref_type != 'tag' && github.repository_owner || secrets.DOCKERHUB_USERNAME }}
@@ -151,7 +151,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}${{ startsWith(github.ref, 'refs/tags') && github.repository_owner == 'godwokenrises' && 'nervos' || github.repository_owner }}/${{ env.IMAGE_NAME }}
           # dynamically set date as a suffix
@@ -179,7 +179,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
         if: ${{ github.ref_type != 'tag' }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile
@@ -191,7 +191,7 @@ jobs:
       # only for new tag
       - name: Build and push Docker image to https://hub.docker.com/r/nervos/godwoken-prebuilds
         if: ${{ github.repository_owner == 'godwokenrises' && startsWith(github.ref, 'refs/tags') }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Print the references of components
         run: |
           echo ref.component.godwoken=${{ steps.prepare.outputs.GODWOKEN_REF }}
-          echo ref.component.godwoken-scripts=${{ steps.prepare.outputs.GODWOKEN_SCRIPTS_REF }}
+          echo ref.component.godwoken-scripts=${{ steps.prepare.outputs.GODWOKEN_REF }}
           echo ref.component.godwoken-polyjuice=${{ steps.prepare.outputs.POLYJUICE_REF }}
           echo ref.component.ckb-production-scripts=${{ steps.prepare.outputs.OMNI_LOCK_REF }}
 
@@ -100,14 +100,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            build/godwoken-scripts/build/release/*
-            build/godwoken-scripts/c/build/*-generator
-            build/godwoken-scripts/c/build/*-validator
-            build/godwoken-scripts/c/build/account_locks/*
-          key: component.godwoken-scripts-${{ steps.prepare.outputs.godwoken-scripts-sha1 }}
-      - name: Build godwoken-scripts
+            build/godwoken/gwos/build/release/*
+            build/godwoken/gwos/build/*-generator
+            build/godwoken/gwos/build/*-validator
+            build/godwoken/gwos/build/account_locks/*
+          key: component.godwoken-scripts-${{ hashFiles('build/godwoken/gwos/**') }}
+      - name: Build godwoken-scripts a.k.a gwos
         if: steps.godwoken-scripts-cache.outputs.cache-hit != 'true'
-        working-directory: build/godwoken-scripts
+        working-directory: build/godwoken/gwos
         run: cd c && make && cd .. && capsule build --release --debug-output
 
       - name: Cache of component.godwoken-polyjuice
@@ -163,13 +163,13 @@ jobs:
             maintainer=Godwoken Core Dev
             org.opencontainers.image.authors=Godwoken Core Dev
             source.component.godwoken=https://github.com/godwokenrises/godwoken
-            source.component.godwoken-scripts-Scripts=https://github.com/godwokenrises/godwoken-scripts
+            source.component.godwoken-scripts=https://github.com/godwokenrises/godwoken/tree/develop/gwos
             source.component.godwoken-polyjuice=https://github.com/godwokenrises/godwoken-polyjuice
             source.component.ckb-production-scripts=https://github.com/nervosnetwork/ckb-production-scripts
             ref.component.godwoken=${{ steps.prepare.outputs.GODWOKEN_REF }}
             ref.component.godwoken-sha1=${{ steps.prepare.outputs.godwoken-sha1 }}
-            ref.component.godwoken-scripts=${{ steps.prepare.outputs.GODWOKEN_SCRIPTS_REF }}
-            ref.component.godwoken-scripts-sha1=${{ steps.prepare.outputs.godwoken-scripts-sha1 }}
+            ref.component.godwoken-scripts=${{ steps.prepare.outputs.GODWOKEN_REF }}
+            ref.component.godwoken-scripts-sha1=${{ steps.prepare.outputs.godwoken-sha1 }}
             ref.component.godwoken-polyjuice=${{ steps.prepare.outputs.POLYJUICE_REF }}
             ref.component.godwoken-polyjuice-sha1=${{ steps.prepare.outputs.godwoken-polyjuice-sha1 }}
             ref.component.ckb-production-scripts=${{ steps.prepare.outputs.OMNI_LOCK_REF }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   docker-build-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # Map the meta step outputs to this job outputs
     outputs:
       image_name: ${{ steps.result.outputs.image_name }}
@@ -137,9 +137,9 @@ jobs:
         with:
           path: |
             build/godwoken/target
-          key: ${{ runner.os }}-cargo-${{ github.sha }}
+          key: ${{ runner.os }}-focal-cargo-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-focal-cargo-
       - name: Build godwoken
         # if: steps.godwoken-cache.outputs.cache-hit != 'true'
         working-directory: build/godwoken

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -105,7 +105,7 @@ jobs:
             build/godwoken/gwos/c/build/*-validator
             build/godwoken/gwos/c/build/account_locks/*
           key: component.gwos-${{ hashFiles('build/godwoken/gwos/**') }}
-      - name: Build gwos a.k.a gwos
+      - name: Build gwos binaries
         if: steps.gwos-cache.outputs.cache-hit != 'true'
         working-directory: build/godwoken/gwos
         run: cd c && make && cd .. && capsule build --release --debug-output
@@ -163,7 +163,7 @@ jobs:
             maintainer=Godwoken Core Dev
             org.opencontainers.image.authors=Godwoken Core Dev
             source.component.godwoken=https://github.com/godwokenrises/godwoken
-            source.component.gwos=https://github.com/godwokenrises/godwoken/tree/develop/gwos
+            source.component.gwos=https://github.com/godwokenrises/godwoken/tree/${{steps.prepare.outputs.GODWOKEN_REF }}/gwos
             source.component.godwoken-polyjuice=https://github.com/godwokenrises/godwoken-polyjuice
             source.component.ckb-production-scripts=https://github.com/nervosnetwork/ckb-production-scripts
             ref.component.godwoken=${{ steps.prepare.outputs.GODWOKEN_REF }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Print the references of components
         run: |
           echo ref.component.godwoken=${{ steps.prepare.outputs.GODWOKEN_REF }}
-          echo ref.component.godwoken-scripts=${{ steps.prepare.outputs.GODWOKEN_REF }}
+          echo ref.component.gwos=${{ steps.prepare.outputs.GODWOKEN_REF }}
           echo ref.component.godwoken-polyjuice=${{ steps.prepare.outputs.POLYJUICE_REF }}
           echo ref.component.ckb-production-scripts=${{ steps.prepare.outputs.OMNI_LOCK_REF }}
 
@@ -95,18 +95,18 @@ jobs:
         working-directory: build/ckb-production-scripts
         run: make all-via-docker
 
-      - name: Cache of component.godwoken-scripts
-        id: godwoken-scripts-cache
+      - name: Cache of component.gwos
+        id: gwos-cache
         uses: actions/cache@v3
         with:
           path: |
             build/godwoken/gwos/build/release/*
-            build/godwoken/gwos/build/*-generator
-            build/godwoken/gwos/build/*-validator
-            build/godwoken/gwos/build/account_locks/*
-          key: component.godwoken-scripts-${{ hashFiles('build/godwoken/gwos/**') }}
-      - name: Build godwoken-scripts a.k.a gwos
-        if: steps.godwoken-scripts-cache.outputs.cache-hit != 'true'
+            build/godwoken/gwos/c/build/*-generator
+            build/godwoken/gwos/c/build/*-validator
+            build/godwoken/gwos/c/build/account_locks/*
+          key: component.gwos-${{ hashFiles('build/godwoken/gwos/**') }}
+      - name: Build gwos a.k.a gwos
+        if: steps.gwos-cache.outputs.cache-hit != 'true'
         working-directory: build/godwoken/gwos
         run: cd c && make && cd .. && capsule build --release --debug-output
 
@@ -141,13 +141,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-focal-cargo-
       - name: Build godwoken
-        # if: steps.godwoken-cache.outputs.cache-hit != 'true'
+        if: steps.godwoken-cache.outputs.cache-hit != 'true'
         working-directory: build/godwoken
         # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2, that means "mostly portable".
         # see also: https://github.com/nervosnetwork/rust-rocksdb/blob/2de3ae5e5e23a315a477bd24e700eb4f5ef7a378/librocksdb-sys/build_detect_platform#L696-L699
-        run: |
-          cargo clean
-          rustup component add rustfmt && PORTABLE=1 USE_SSE=1 RUSTFLAGS="-C target-cpu=skylake" CARGO_PROFILE_RELEASE_LTO=true cargo build --release
+        run: rustup component add rustfmt && PORTABLE=1 USE_SSE=1 RUSTFLAGS="-C target-cpu=skylake" CARGO_PROFILE_RELEASE_LTO=true cargo build --release
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -165,13 +163,13 @@ jobs:
             maintainer=Godwoken Core Dev
             org.opencontainers.image.authors=Godwoken Core Dev
             source.component.godwoken=https://github.com/godwokenrises/godwoken
-            source.component.godwoken-scripts=https://github.com/godwokenrises/godwoken/tree/develop/gwos
+            source.component.gwos=https://github.com/godwokenrises/godwoken/tree/develop/gwos
             source.component.godwoken-polyjuice=https://github.com/godwokenrises/godwoken-polyjuice
             source.component.ckb-production-scripts=https://github.com/nervosnetwork/ckb-production-scripts
             ref.component.godwoken=${{ steps.prepare.outputs.GODWOKEN_REF }}
             ref.component.godwoken-sha1=${{ steps.prepare.outputs.godwoken-sha1 }}
-            ref.component.godwoken-scripts=${{ steps.prepare.outputs.GODWOKEN_REF }}
-            ref.component.godwoken-scripts-sha1=${{ steps.prepare.outputs.godwoken-sha1 }}
+            ref.component.gwos=${{ steps.prepare.outputs.GODWOKEN_REF }}
+            ref.component.gwos-sha1=${{ steps.prepare.outputs.godwoken-sha1 }}
             ref.component.godwoken-polyjuice=${{ steps.prepare.outputs.POLYJUICE_REF }}
             ref.component.godwoken-polyjuice-sha1=${{ steps.prepare.outputs.godwoken-polyjuice-sha1 }}
             ref.component.ckb-production-scripts=${{ steps.prepare.outputs.OMNI_LOCK_REF }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -141,11 +141,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: Build godwoken
-        if: steps.godwoken-cache.outputs.cache-hit != 'true'
+        # if: steps.godwoken-cache.outputs.cache-hit != 'true'
         working-directory: build/godwoken
         # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2, that means "mostly portable".
         # see also: https://github.com/nervosnetwork/rust-rocksdb/blob/2de3ae5e5e23a315a477bd24e700eb4f5ef7a378/librocksdb-sys/build_detect_platform#L696-L699
-        run: rustup component add rustfmt && PORTABLE=1 USE_SSE=1 RUSTFLAGS="-C target-cpu=skylake" CARGO_PROFILE_RELEASE_LTO=true cargo build --release
+        run: |
+          cargo clean
+          rustup component add rustfmt && PORTABLE=1 USE_SSE=1 RUSTFLAGS="-C target-cpu=skylake" CARGO_PROFILE_RELEASE_LTO=true cargo build --release
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -213,8 +215,8 @@ jobs:
       - name: Record image info to the outputs of this jobs
         id: result
         run: |
-          echo "::set-output name=image_name::`echo ${{ fromJSON(steps.meta.outputs.json).tags[0] }} | awk -F ':' '{print $1}'`"
-          echo "::set-output name=image_tag::`echo ${{ fromJSON(steps.meta.outputs.json).tags[0] }} | awk -F ':' '{print $NF}'`"
+          echo "image_name=`echo ${{ fromJSON(steps.meta.outputs.json).tags[0] }} | awk -F ':' '{print $1}'`" >> $GITHUB_OUTPUT
+          echo "image_tag=`echo ${{ fromJSON(steps.meta.outputs.json).tags[0] }} | awk -F ':' '{print $NF}'`" >> $GITHUB_OUTPUT
 
   integration-test:
     needs: docker-build-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ghcr.io/godwokenrises/godwoken-prebuilds:dev-poly1.5.0 as historical-versio
 
 FROM ubuntu:focal
 LABEL description="Docker image containing all binaries used by Godwoken, saving you the hassles of building them yourself."
-LABEL maintainer="Nervos Core Dev <dev@nervos.org>"
+LABEL maintainer="Godwoken Core Dev"
 
 RUN mkdir -p /scripts/godwoken-scripts \
  && mkdir -p /scripts/godwoken-polyjuice \
@@ -58,7 +58,7 @@ COPY build/godwoken-polyjuice/build/*generator* \
      build/godwoken-polyjuice/build/*validator* \
      /scripts/godwoken-polyjuice/
 # TODO: remove *.aot in Polyjuice Makefile
-RUN find /scripts -type f -name '*.aot' -exec rm {} \;
+# RUN find /scripts -type f -name '*.aot' -exec rm {} \;
 
 # /scripts/omni-lock and /scripts/godwoken-scripts
 COPY build/ckb-production-scripts/build/omni_lock \

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,28 +50,31 @@ COPY --from=historical-versions /scripts/godwoken-polyjuice-v1.4.5/ \
 COPY --from=historical-versions /scripts/godwoken-polyjuice/* \
                                 /scripts/godwoken-polyjuice-v1.5.0/
 
-# TODO: find /scripts -type f -name '*.aot' -exec rm {} \;
-
 #################################### latest ####################################
-# /scripts/omni-lock
-COPY build/ckb-production-scripts/build/omni_lock /scripts/godwoken-scripts/
-
-# /scripts/godwoken-scripts
-COPY build/godwoken-scripts/build/release/* /scripts/godwoken-scripts/
-COPY build/godwoken-scripts/c/build/*-generator /scripts/godwoken-scripts/
-COPY build/godwoken-scripts/c/build/*-validator /scripts/godwoken-scripts/
-COPY build/godwoken-scripts/c/build/account_locks/* /scripts/godwoken-scripts/
+# COPY [--chown=<user>:<group>] ["<src>",... "<dest>"]
 
 # /scripts/godwoken-polyjuice
-COPY build/godwoken-polyjuice/build/*generator* /scripts/godwoken-polyjuice/
-COPY build/godwoken-polyjuice/build/*validator* /scripts/godwoken-polyjuice/
-################################################################################
+COPY build/godwoken-polyjuice/build/*generator* \
+     build/godwoken-polyjuice/build/*validator* \
+     /scripts/godwoken-polyjuice/
+# TODO: remove *.aot in Polyjuice Makefile
+RUN find /scripts -type f -name '*.aot' -exec rm {} \;
 
+# /scripts/omni-lock and /scripts/godwoken-scripts
+COPY build/ckb-production-scripts/build/omni_lock \
+     build/godwoken/gwos/build/release/* \
+     build/godwoken/gwos/c/build/*-generator \ 
+     build/godwoken/gwos/c/build/*-validator \
+     build/godwoken/gwos/c/build/account_locks/* \
+     /scripts/godwoken-scripts/
 
 # godwoken
-COPY build/godwoken/target/release/godwoken /bin/godwoken
-COPY build/godwoken/target/release/gw-tools /bin/gw-tools
-COPY gw-healthcheck.sh /bin/gw-healthcheck.sh
+COPY build/godwoken/target/release/godwoken \
+     build/godwoken/target/release/gw-tools \
+     gw-healthcheck.sh \
+     /bin/
+################################################################################
+
 
 WORKDIR /deploy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM ghcr.io/godwokenrises/godwoken-prebuilds:dev-poly1.5.0 as historical-versio
 
 ################################################################################
 
+# https://hub.docker.com/_/ubuntu/
 FROM ubuntu:focal
 LABEL description="Docker image containing all binaries used by Godwoken, saving you the hassles of building them yourself."
 LABEL maintainer="Godwoken Core Dev"

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ build-push:
 
 test:
 	make build-components
-	docker build . -t nervos/godwoken-prebuilds:latest-test
+	docker build . -t godwokenrises/godwoken-prebuilds:latest-test
 	mkdir -p `pwd`/test-result/scripts
 	mkdir -p `pwd`/test-result/bin
-	docker run -it -d --name dummy nervos/godwoken-prebuilds:latest-test
+	docker run -it -d --name dummy godwokenrises/godwoken-prebuilds:latest-test
 	docker cp dummy:/scripts/. `pwd`/test-result/scripts
 	docker cp dummy:/bin/godwoken `pwd`/test-result/bin
 	docker cp dummy:/bin/gw-tools `pwd`/test-result/bin

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,11 @@ SHELL := /bin/bash
 
 # components repos
 GODWOKEN_REPO := https://github.com/godwokenrises/godwoken.git
-GODWOKEN_SCRIPTS_REPO := https://github.com/godwokenrises/godwoken-scripts.git
 POLYJUICE_REPO := https://github.com/godwokenrises/godwoken-polyjuice.git
 OMNI_LOCK_REPO := https://github.com/nervosnetwork/ckb-production-scripts.git
 
 # components tags
 GODWOKEN_REF := refs/pull/836/merge # https://github.com/godwokenrises/godwoken/pull/836
-GODWOKEN_SCRIPTS_REF := v1.3.0-rc1 # https://github.com/godwokenrises/godwoken-scripts/compare/v1.1.0-beta...v1.3.0-rc1
 POLYJUICE_REF := 1.5.0 # https://github.com/godwokenrises/godwoken-polyjuice/compare/1.4.6...1.5.0
 OMNI_LOCK_REF := rc_lock
 
@@ -27,8 +25,6 @@ prepare-repos:
 	mkdir -p build
 	$(call prepare_repo,$(GODWOKEN_REPO),$(GODWOKEN_REF),godwoken)
 	echo "::set-output name=GODWOKEN_REF::$(GODWOKEN_REF) $$(cd build/godwoken && git rev-parse --short HEAD)" >> versions
-	$(call prepare_repo,$(GODWOKEN_SCRIPTS_REPO),$(GODWOKEN_SCRIPTS_REF),godwoken-scripts)
-	echo "::set-output name=GODWOKEN_SCRIPTS_REF::$(GODWOKEN_SCRIPTS_REF) $$(cd build/godwoken-scripts && git rev-parse --short HEAD)" >> versions
 	$(call prepare_repo,$(POLYJUICE_REPO),$(POLYJUICE_REF),godwoken-polyjuice)
 	echo "::set-output name=POLYJUICE_REF::$(POLYJUICE_REF) $$(cd build/godwoken-polyjuice && git rev-parse --short HEAD)" >> versions
 	$(call prepare_repo,$(OMNI_LOCK_REPO),$(OMNI_LOCK_REF),ckb-production-scripts)
@@ -36,7 +32,7 @@ prepare-repos:
 
 build-components: prepare-repos
 	cd build/godwoken-polyjuice && make dist && cd -
-	cd build/godwoken-scripts && cd c && make && cd .. && capsule build --release --debug-output && cd ../..
+	cd build/godwoken/gwos && cd c && make && cd .. && capsule build --release --debug-output && cd ../..
 	cd build/ckb-production-scripts && make all-via-docker
 	cd build/godwoken && rustup component add rustfmt && RUSTFLAGS="-C target-cpu=native" CARGO_PROFILE_RELEASE_LTO=true cargo build --release
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ POLYJUICE_REPO := https://github.com/godwokenrises/godwoken-polyjuice.git
 OMNI_LOCK_REPO := https://github.com/nervosnetwork/ckb-production-scripts.git
 
 # components tags
-GODWOKEN_REF := v1.7.1 # https://github.com/godwokenrises/godwoken/compare/v1.7.0...v1.7.1
+GODWOKEN_REF := refs/pull/836/merge # https://github.com/godwokenrises/godwoken/pull/836
 GODWOKEN_SCRIPTS_REF := v1.3.0-rc1 # https://github.com/godwokenrises/godwoken-scripts/compare/v1.1.0-beta...v1.3.0-rc1
 POLYJUICE_REF := 1.5.0 # https://github.com/godwokenrises/godwoken-polyjuice/compare/1.4.6...1.5.0
 OMNI_LOCK_REF := rc_lock


### PR DESCRIPTION
godwoken-scripts was moved into Godwoken monorepo, so we need to adapt
the building workflow.

## The image containing latest godwoken-scripts
`docker pull ghcr.io/flouse/godwoken-prebuilds:dev.pull.836.merge-gwos`
> https://github.com/Flouse/godwoken-docker-prebuilds/pkgs/container/godwoken-prebuilds