### PR TITLE
ci: replace set-output syntax and upgrade dep actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,7 +64,7 @@ jobs:
       # GitHub automatically creates a unique GITHUB_TOKEN secret to use in this workflow.
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.ref_type != 'tag' && github.repository_owner || secrets.DOCKERHUB_USERNAME }}
@@ -151,7 +151,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}${{ startsWith(github.ref, 'refs/tags') && github.repository_owner == 'godwokenrises' && 'nervos' || github.repository_owner }}/${{ env.IMAGE_NAME }}
           # dynamically set date as a suffix
@@ -179,7 +179,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
         if: ${{ github.ref_type != 'tag' }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile
@@ -191,7 +191,7 @@ jobs:
       # only for new tag
       - name: Build and push Docker image to https://hub.docker.com/r/nervos/godwoken-prebuilds
         if: ${{ github.repository_owner == 'godwokenrises' && startsWith(github.ref, 'refs/tags') }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile
@@ -213,8 +213,8 @@ jobs:
       - name: Record image info to the outputs of this jobs
         id: result
         run: |
-          echo "::set-output name=image_name::`echo ${{ fromJSON(steps.meta.outputs.json).tags[0] }} | awk -F ':' '{print $1}'`"
-          echo "::set-output name=image_tag::`echo ${{ fromJSON(steps.meta.outputs.json).tags[0] }} | awk -F ':' '{print $NF}'`"
+          echo "image_name=`echo ${{ fromJSON(steps.meta.outputs.json).tags[0] }} | awk -F ':' '{print $1}'`" >> $GITHUB_OUTPUT
+          echo "image_tag=`echo ${{ fromJSON(steps.meta.outputs.json).tags[0] }} | awk -F ':' '{print $NF}'`" >> $GITHUB_OUTPUT
 
   integration-test:
     needs: docker-build-push

--- a/Makefile
+++ b/Makefile
@@ -20,19 +20,19 @@ define prepare_repo
 	git fetch origin $(2);\
 	git checkout FETCH_HEAD;\
 	git submodule update --init --recursive --depth=1;\
-	echo "::set-output name=$(3)-sha1::$$(git rev-parse HEAD)" >> ../../versions
+	echo "$(3)-sha1=$$(git rev-parse HEAD)" >> ../../versions
 endef
 
 prepare-repos:
 	mkdir -p build
 	$(call prepare_repo,$(GODWOKEN_REPO),$(GODWOKEN_REF),godwoken)
-	echo "::set-output name=GODWOKEN_REF::$(GODWOKEN_REF) $$(cd build/godwoken && git rev-parse --short HEAD)" >> versions
+	echo "GODWOKEN_REF=$(GODWOKEN_REF) $$(cd build/godwoken && git rev-parse --short HEAD)" >> versions
 	$(call prepare_repo,$(GODWOKEN_SCRIPTS_REPO),$(GODWOKEN_SCRIPTS_REF),godwoken-scripts)
-	echo "::set-output name=GODWOKEN_SCRIPTS_REF::$(GODWOKEN_SCRIPTS_REF) $$(cd build/godwoken-scripts && git rev-parse --short HEAD)" >> versions
+	echo "GODWOKEN_SCRIPTS_REF=$(GODWOKEN_SCRIPTS_REF) $$(cd build/godwoken-scripts && git rev-parse --short HEAD)" >> versions
 	$(call prepare_repo,$(POLYJUICE_REPO),$(POLYJUICE_REF),godwoken-polyjuice)
-	echo "::set-output name=POLYJUICE_REF::$(POLYJUICE_REF) $$(cd build/godwoken-polyjuice && git rev-parse --short HEAD)" >> versions
+	echo "POLYJUICE_REF=$(POLYJUICE_REF) $$(cd build/godwoken-polyjuice && git rev-parse --short HEAD)" >> versions
 	$(call prepare_repo,$(OMNI_LOCK_REPO),$(OMNI_LOCK_REF),ckb-production-scripts)
-	echo "::set-output name=OMNI_LOCK_REF::$(OMNI_LOCK_REF) $$(cd build/ckb-production-scripts && git rev-parse --short HEAD)" >> versions
+	echo "OMNI_LOCK_REF=$(OMNI_LOCK_REF) $$(cd build/ckb-production-scripts && git rev-parse --short HEAD)" >> versions
 
 build-components: prepare-repos
 	cd build/godwoken-polyjuice && make dist && cd -


### PR DESCRIPTION
### Description
Command set-output/save-state is deprecated, and node@12  is also deprecated in GitHub action's runner.
To make sure everything works in the future, in this PR we should:
- Replace all `set-output` syntax to be in sync with latest standard
- Upgrade dependency actions to get rid of deprecated `node@12` and `save-state`

### Uncertain things
In the [official blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), we were told that the `set-output` should be refactored like:
```yml
# from
- name: Set output
  run: echo "::set-output name={name}::{value}"
# to
- name: Set output
  run: echo "{name}={value}" >> $GITHUB_OUTPUT
```

The simplicity of the example make me feel uncertain about this specific case:
```shell
echo "::set-output name=$(3)-sha1::$$(git rev-parse HEAD)" >> ../../versions
```
How should I deal with this case, have I done it in the right way?
@Flouse Can you help me check on this, or should we just run the ci for a result?

### Related issues
- #78 
- #79 
- #83 